### PR TITLE
Using assertInstance to check instance

### DIFF
--- a/tests/ArchiveBombScannerTest.php
+++ b/tests/ArchiveBombScannerTest.php
@@ -22,9 +22,7 @@ class ArchiveBombScannerTest extends TestCase
      */
     public function testCreateInstance(): void
     {
-        new ArchiveBombScanner();
-
-        self::assertTrue(true);
+        self::assertInstanceOf(ArchiveBombScanner::class, new ArchiveBombScanner());
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Using the `assertInstanceOf` assertion to check whether the instance is same as result.