### PR TITLE
Add ext-zip inside suggest block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "phpstan/phpstan-shim": "^0.11",
         "squizlabs/php_codesniffer": "^3.4"
     },
+    "suggest": {
+        "ext-zip": "Using this extension to detect ZIP archive bomb"
+    },
     "scripts": {
         "test": "phpunit --configuration phpunit.xml",
         "test-coverage": "phpunit --configuration phpunit.xml --coverage-clover build/logs/clover.xml --coverage-html build/coverage",


### PR DESCRIPTION
# Changed log
- Adding the `ext-zip` extension suggestion inside `suggest` block in `composer.json`.
It reminds that developers detect ZIP archive bombs to ensure the `ZIP` extension is loaded.